### PR TITLE
Correct link in nav to use correct model method for user avatar

### DIFF
--- a/app/views/shared/_nav.html.haml
+++ b/app/views/shared/_nav.html.haml
@@ -5,4 +5,4 @@
     %li= link_to "Proposals", "#"
     %li= link_to "Conferences", "#"
     %li= link_to "Sign Out", sign_out_path
-    %li= image_tag current_user.avatar_url, :class => 'avatar'
+    %li= image_tag current_user.avatar, :class => 'avatar'


### PR DESCRIPTION
We discussed User#avatar vs. User#avatar_url. Everything in the model says "avatar", but the link in the nav view partial was "avatar_url". I'm not sure which way we decided to go...
